### PR TITLE
fix(data-conversion): fix for moment format being falsy read of 'MMM k'

### DIFF
--- a/libs/data-conversion.test.ts
+++ b/libs/data-conversion.test.ts
@@ -56,6 +56,14 @@ describe("test to ensure cleanseDate is giving the correct result", () => {
     expect(typeof cleansedDate).toBe("string");
     expect(cleansedDate).toBe("Jul 30");
   });
+
+  test("cleanseDate to return month and date only when format is MMM k", () => {
+    const rawDate = "Sep 4";
+    const cleansedDate = exportedForTesting.cleanseDate(rawDate);
+    expect(cleansedDate).toBeDefined();
+    expect(typeof cleansedDate).toBe("string");
+    expect(cleansedDate).toBe("Sep 4");
+  });
 });
 
 describe("convertTo24HourFormat to return the correct format", () => {

--- a/libs/data-conversion.ts
+++ b/libs/data-conversion.ts
@@ -9,13 +9,14 @@ import { Team } from "../constants/team";
 import { Time, defaultTimeFormat, TBDFormat } from "../constants/time-conversion";
 
 function cleanseDate(date: string): string {
-  const excludedMomentFormats = ["MMM YY", "ddd, MMM YY", "ddd, MMM k"];
+  const excludedMomentFormats = ["MMM YY", "ddd, MMM YY", "ddd, MMM k", "MMM k"];
   const momentFormat = parseFormat(date);
   let clean;
   /**
    * excluded because it's being falsy read
    * e.g.
    * Jul 30 being read as MMM YYY instead of MMM D
+   * Sep 4 being read as MMM k instead of MMM D
    * Sat, Jul 30 being read as ddd, MMM YY instead of ddd, MMM D
    * Sat, Aug 6 being read as ddd, MMM k instead of ddd, MMM D
    */


### PR DESCRIPTION
Resolves #25 

Checklist
- [x] Unit test updated
- [x] Manual test locally

Screenshot of the test