### PR TITLE
fix: remove incomplete data from serp API result

### DIFF
--- a/interfaces/serp-api.ts
+++ b/interfaces/serp-api.ts
@@ -6,8 +6,8 @@ interface Teams {
 export interface SingleFixture {
   teams: Teams[];
   participants?: string;
-  date: string;
-  time: string;
+  date?: string;
+  time?: string;
   date_time?: Date;
   stage?: string;
   tournament: string;

--- a/libs/data-conversion.test.ts
+++ b/libs/data-conversion.test.ts
@@ -2,8 +2,76 @@ import {
   addHours,
   convertToStandardSerpAPIResults,
   exportedForTesting,
-  serpApiToRedis
+  serpApiToRedis,
+  removeIncompleteSerpAPIData
 } from "./data-conversion";
+
+describe("test to remove incomplete data", () => {
+  test("removeIncompleteSerpAPIData to return empty array if objects inside array don't have any date and time information", () => {
+    const rawData = [
+      {
+        teams: [
+          {
+            name: "First Club Football"
+          },
+          {
+            name: "Second Club Football"
+          }
+        ],
+        tournament: "Competition Cup",
+        stadium: "Homeground Stadium"
+      },
+      {
+        teams: [
+          {
+            name: "First Club Football (2)"
+          },
+          {
+            name: "Second Club Football (2)"
+          }
+        ],
+        tournament: "Competition Cup (2)",
+        stadium: "Homeground Stadium (2)"
+      }
+    ]
+    const completedData = exportedForTesting.removeIncompleteSerpAPIData(rawData);
+    expect(completedData).toEqual([]);
+  });
+
+  test("removeIncompleteSerpAPIData to return an array of an object if some of the objects inside array don't have any date and time information", () => {
+    const rawData = [
+      {
+        teams: [
+          {
+            name: "First Club Football"
+          },
+          {
+            name: "Second Club Football"
+          }
+        ],
+        tournament: "Competition Cup",
+        stadium: "Homeground Stadium",
+        date: "Feb 20",
+        time: "7:15 PM"
+      },
+      {
+        teams: [
+          {
+            name: "First Club Football (2)"
+          },
+          {
+            name: "Second Club Football (2)"
+          }
+        ],
+        tournament: "Competition Cup (2)",
+        stadium: "Homeground Stadium (2)"
+      }
+    ]
+    const completedData = exportedForTesting.removeIncompleteSerpAPIData(rawData);
+    expect(completedData).toHaveLength(1);
+    expect(completedData[0].time).toEqual("7:15 PM");
+  })
+})
 
 describe("test to ensure cleanseDate is giving the correct result", () => {
   test("cleanseDate to return month and date only when format is ddd, MMM D", () => {

--- a/libs/data-conversion.test.ts
+++ b/libs/data-conversion.test.ts
@@ -2,8 +2,7 @@ import {
   addHours,
   convertToStandardSerpAPIResults,
   exportedForTesting,
-  serpApiToRedis,
-  removeIncompleteSerpAPIData
+  serpApiToRedis
 } from "./data-conversion";
 
 describe("test to remove incomplete data", () => {

--- a/libs/data-conversion.ts
+++ b/libs/data-conversion.ts
@@ -13,7 +13,7 @@ const MOMENT_DEFAULT_FORMAT = "MMM D";
 function cleanseDate(date: string): string {
   const excludedMomentFormats = ["MMM YY", "ddd, MMM YY", "ddd, MMM k", "MMM k"];
   const momentFormat = parseFormat(date);
-  let clean;
+  let clean: string;
   /**
    * excluded because it's being falsy read
    * e.g.
@@ -29,6 +29,10 @@ function cleanseDate(date: string): string {
     clean = moment(date, momentFormat).format(MOMENT_DEFAULT_FORMAT);
   }
   return clean;
+}
+
+export function removeIncompleteSerpAPIData(fixtures: SingleFixture[]): SingleFixture[] {
+  return fixtures.filter(f => f.time !== undefined && f.date !== undefined);
 }
 
 function convertTo24HourFormat(time: string): string {
@@ -131,5 +135,6 @@ export const exportedForTesting = {
   convertDateTimeToUTC,
   convertTo24HourFormat,
   cleanseDate,
-  convertToTwitterAccountForChelseaFC
+  convertToTwitterAccountForChelseaFC,
+  removeIncompleteSerpAPIData
 };


### PR DESCRIPTION
Fix an issue where once of the fixtures is `postponed`. Solution is just to remove it from the fixtures because date and time aren't fixed yet. 

Checklist
- [x] Unit test updated
- [x] Manual test locally

Screenshot of the test