### PR TITLE
chore: remove the usage of `any` type by declaring the contract of Serp API response

### DIFF
--- a/constants/team.ts
+++ b/constants/team.ts
@@ -1,4 +1,4 @@
-export const Team: { [key: string]: string } = {
+export const Team = {
   name: "Chelsea",
   stadium: "Stamford Bridge",
   hashtag: "#ChelseaFC #CFCFixture",

--- a/constants/tournament.ts
+++ b/constants/tournament.ts
@@ -1,4 +1,4 @@
-export const Tournament: { [key: string]: string } = {
+export const Tournament = {
   PL: "#PL",
   UCL: "#UCL",
   FACUP: "#FACup",

--- a/events/subscriber.ts
+++ b/events/subscriber.ts
@@ -1,5 +1,3 @@
-import Redis from "ioredis";
-
 import { injectEnv } from "../libs/inject-env";
 import { RedisTerms } from "../constants/redis";
 import { HTTP } from "../modules/http";

--- a/interfaces/serp-api.ts
+++ b/interfaces/serp-api.ts
@@ -17,9 +17,9 @@ export interface SingleFixture {
 
 export interface GameSpotlight {
   teams: Teams[];
+  stadium: string;
   league?: string;
   tournament?: string;
-  stadium: string;
   date?: string;
   time?: string;
 }

--- a/interfaces/serp-api.ts
+++ b/interfaces/serp-api.ts
@@ -5,11 +5,21 @@ interface Teams {
 
 export interface SingleFixture {
   teams: Teams[];
+  tournament: string;
+  stadium: string;
   participants?: string;
   date?: string;
   time?: string;
   date_time?: Date;
   stage?: string;
-  tournament: string;
+  league?: string;
+}
+
+export interface GameSpotlight {
+  teams: Teams[];
+  league?: string;
+  tournament?: string;
   stadium: string;
+  date?: string;
+  time?: string;
 }

--- a/libs/data-conversion.test.ts
+++ b/libs/data-conversion.test.ts
@@ -274,8 +274,8 @@ describe("convertToTwitterAccountForChelseaFC to return the correct format for t
 });
 
 describe("convertToStandardSerpAPIResults to return the correct and standard format of serp API result", () => {
-  test("convertToStandardSerpAPIResults to return the standard format of game result from game highlight when 'tomorrow' date is provided inside game_spotlight", async () => {
-    const gameHighlight = {
+  test("convertToStandardSerpAPIResults to return the standard format of game result from game spotlight when 'tomorrow' date is provided inside game_spotlight", async () => {
+    const gameSpotlight = {
       league: "Florida Cup",
       date: "tomorrow, 7:00 am",
       stage: "Finale",
@@ -286,16 +286,17 @@ describe("convertToStandardSerpAPIResults to return the correct and standard for
         {
           name: "Arsenal"
         }
-      ]
+      ],
+      stadium: "Stamford Bridge"
     };
-    const convertedGameHighlight = await convertToStandardSerpAPIResults(gameHighlight, true);
-    expect(typeof convertedGameHighlight).toBe("object");
-    expect(typeof convertedGameHighlight.date).toBe("string");
-    expect(convertedGameHighlight.time).toEqual("7:00 am");
+    const convertedGameSpotlight = await convertToStandardSerpAPIResults(gameSpotlight, true);
+    expect(typeof convertedGameSpotlight).toBe("object");
+    expect(typeof convertedGameSpotlight.date).toBe("string");
+    expect(convertedGameSpotlight.time).toEqual("7:00 am");
   });
 
   test("convertToStandardSerpAPIResults to return the standard format of game result from game highlight when 'today' date is provided outside of game_spotlight", async () => {
-    const gameHighlight = {
+    const gameSpotlight = {
       league: "Florida Cup",
       date: "today",
       time: "11:00 am",
@@ -307,11 +308,12 @@ describe("convertToStandardSerpAPIResults to return the correct and standard for
         {
           name: "Arsenal"
         }
-      ]
+      ],
+      stadium: "Stamford Bridge"
     };
-    const convertedGameHighlight = await convertToStandardSerpAPIResults(gameHighlight, false);
-    expect(typeof convertedGameHighlight).toBe("object");
-    expect(typeof convertedGameHighlight.date).toBe("string");
-    expect(convertedGameHighlight.time).toEqual("11:00 am");
+    const convertedGameSpotlight = await convertToStandardSerpAPIResults(gameSpotlight, false);
+    expect(typeof convertedGameSpotlight).toBe("object");
+    expect(typeof convertedGameSpotlight.date).toBe("string");
+    expect(convertedGameSpotlight.time).toEqual("11:00 am");
   });
 });

--- a/libs/data-conversion.ts
+++ b/libs/data-conversion.ts
@@ -2,7 +2,7 @@
 import parseFormat = require("moment-parseformat");
 import moment = require("moment");
 
-import { SingleFixture } from "../interfaces/serp-api";
+import { SingleFixture, GameSpotlight } from "../interfaces/serp-api";
 import { RedisFixture } from "../interfaces/redis";
 import { PartialMonthToIndex } from "../enums/months";
 import { Team } from "../constants/team";
@@ -85,7 +85,7 @@ function convertToTwitterAccountForChelseaFC(team: string): string {
 
 export async function convertToStandardSerpAPIResults(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: any,
+  data: GameSpotlight | SingleFixture,
   fromSpotlight: boolean
 ): Promise<Record<string, unknown>> {
   let time: unknown, date: string | string[];

--- a/libs/data-conversion.ts
+++ b/libs/data-conversion.ts
@@ -84,7 +84,6 @@ function convertToTwitterAccountForChelseaFC(team: string): string {
 }
 
 export async function convertToStandardSerpAPIResults(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: GameSpotlight | SingleFixture,
   fromSpotlight: boolean
 ): Promise<Record<string, unknown>> {


### PR DESCRIPTION
Resolves #[issue-number] (if any)

Checklist
- [x] Unit test updated
- [x] Manual test locally

Screenshot of the test