### PR TITLE
fix(date-converter): fix issue of MMMM D being read as MMMM YY

### DIFF
--- a/libs/data-conversion.test.ts
+++ b/libs/data-conversion.test.ts
@@ -128,6 +128,14 @@ describe("test to ensure cleanseDate is giving the correct result", () => {
     expect(typeof cleansedDate).toBe("string");
     expect(cleansedDate).toBe("Sep 4");
   });
+
+  test("cleanseDate to return month and date only when format is MMMM YY", () => {
+    const rawDate = "May 11";
+    const cleansedDate = exportedForTesting.cleanseDate(rawDate);
+    expect(cleansedDate).toBeDefined();
+    expect(typeof cleansedDate).toBe("string");
+    expect(cleansedDate).toBe("May 11");
+  });
 });
 
 describe("convertTo24HourFormat to return the correct format", () => {

--- a/libs/data-conversion.ts
+++ b/libs/data-conversion.ts
@@ -11,7 +11,7 @@ import { Time, defaultTimeFormat, TBDFormat } from "../constants/time-conversion
 const MOMENT_DEFAULT_FORMAT = "MMM D";
 
 function cleanseDate(date: string): string {
-  const excludedMomentFormats = ["MMM YY", "ddd, MMM YY", "ddd, MMM k", "MMM k"];
+  const excludedMomentFormats = ["MMM YY", "ddd, MMM YY", "ddd, MMM k", "MMM k", "MMM DD", "MMMM YY"];
   const momentFormat = parseFormat(date);
   let clean: string;
   /**
@@ -28,6 +28,7 @@ function cleanseDate(date: string): string {
   } else {
     clean = moment(date, momentFormat).format(MOMENT_DEFAULT_FORMAT);
   }
+
   return clean;
 }
 


### PR DESCRIPTION
Resolves the following issue:
```bash
2024-05-10T02:30:56.962831+00:00 app[worker.1]: New message received {
2024-05-10T02:30:56.962988+00:00 app[worker.1]: message: {
2024-05-10T02:30:56.963004+00:00 app[worker.1]: tournament: 'Premier League',
2024-05-10T02:30:56.963006+00:00 app[worker.1]: stadium: 'City Ground',
2024-05-10T02:30:56.963006+00:00 app[worker.1]: date: 'Sat, May 11',
2024-05-10T02:30:56.963011+00:00 app[worker.1]: time: '11:30 PM',
2024-05-10T02:30:56.963011+00:00 app[worker.1]: teams: [ [Object], [Object] ],
2024-05-10T02:30:56.963011+00:00 app[worker.1]: participants: 'Nottm Forest vs @ChelseaFC',
2024-05-10T02:30:56.963012+00:00 app[worker.1]: date_time: null
2024-05-10T02:30:56.963012+00:00 app[worker.1]: },
2024-05-10T02:30:56.963013+00:00 app[worker.1]: hours_to_match: -476474
2024-05-10T02:30:56.963013+00:00 app[worker.1]: }
```

**May 11** is read as `MMMM YY` instead of `MMM D`. Solution: add the format to the exclusion list. 

Checklist
- [x] Unit test updated
- [x] Manual test locally

Screenshot of the test