### PR TITLE
Fix/further date conversion fixes

### DIFF
--- a/jobs/match-fetcher.ts
+++ b/jobs/match-fetcher.ts
@@ -40,7 +40,7 @@ class MatchFetcher {
       if (existingKeyTTL < lowerLimitToFetchAPI) {
         const data = await this.httpController.get(); // TODO: strick-checking data type
         const fixtures = data.sports_results.games;
-        const firstMatchDate = data.sports_results.games[0]?.date?.toLocaleLowerCase().trim();
+        const firstMatchDate = data.sports_results.games[0]?.date?.trim();
         const customDateFormats = ["tomorrow", "today"];
         let gameHighlight;
         if (data.sports_results.game_spotlight) {
@@ -50,12 +50,13 @@ class MatchFetcher {
             true
           );
           fixtures.unshift(gameHighlight);
-        } else if (firstMatchDate && customDateFormats.includes(firstMatchDate)) {
+        } else if (firstMatchDate && customDateFormats.includes(firstMatchDate.toLowerCase())) {
           const firstMatch = fixtures[0];
           fixtures[0] = convertToStandardSerpAPIResults(firstMatch, false);
         }
         const completedData = removeIncompleteSerpAPIData(fixtures);
         const convertedData = serpApiToRedis(completedData);
+
         console.log(`Storing ${convertedData.length} fixture(s) into redis.`)
         await this.redis.set(RedisTerms.keyName, JSON.stringify(convertedData), defaultTTLInSeconds);
       }

--- a/libs/data-conversion.test.ts
+++ b/libs/data-conversion.test.ts
@@ -136,6 +136,14 @@ describe("test to ensure cleanseDate is giving the correct result", () => {
     expect(typeof cleansedDate).toBe("string");
     expect(cleansedDate).toBe("May 11");
   });
+
+  test("cleanseDate to return month and date only when format is ddd, MMMM YY", () => {
+    const rawDate = "Sun, May 19";
+    const cleansedDate = exportedForTesting.cleanseDate(rawDate);
+    expect(cleansedDate).toBeDefined();
+    expect(typeof cleansedDate).toBe("string");
+    expect(cleansedDate).toBe("May 19");
+  });
 });
 
 describe("convertTo24HourFormat to return the correct format", () => {

--- a/libs/data-conversion.ts
+++ b/libs/data-conversion.ts
@@ -11,7 +11,7 @@ import { Time, defaultTimeFormat, TBDFormat } from "../constants/time-conversion
 const MOMENT_DEFAULT_FORMAT = "MMM D";
 
 function cleanseDate(date: string): string {
-  const excludedMomentFormats = ["MMM YY", "ddd, MMM YY", "ddd, MMM k", "MMM k", "MMM DD", "MMMM YY"];
+  const excludedMomentFormats = ["MMM YY", "ddd, MMM YY", "ddd, MMM k", "MMM k", "MMM DD", "MMMM YY", "ddd, MMMM YY"];
   const momentFormat = parseFormat(date);
   let clean: string;
   /**
@@ -77,7 +77,7 @@ function convertDateTimeToUTC(date: string, time: string): Date {
 }
 
 export function removeIncompleteSerpAPIData(fixtures: SingleFixture[]): SingleFixture[] {
-  return fixtures.filter(f => f.time !== undefined && f.date !== undefined);
+  return fixtures.filter(f => f.time !== "TBD" && f.date !== undefined);
 }
 
 function convertToTwitterAccountForChelseaFC(team: string): string {


### PR DESCRIPTION
Resolves the following issues:
1. `Sun, May 16` format isn't handled yet thus resulting to invalid date
2. `TBD` time is read as default value. We instead filter it from the array

Checklist
- [x] Unit test updated
- [x] Manual test locally

Screenshot of the test