### PR TITLE
feat(tweet-content): add UK date and time in tweet content

### DIFF
--- a/libs/tweet.ts
+++ b/libs/tweet.ts
@@ -1,6 +1,9 @@
 import { Emojis } from "../enums/emojis";
 import { MonthIndexToFullMonth } from "../enums/months";
 import { Team } from "../constants/team";
+import momentTz = require('moment-timezone');
+
+const UKTimezoneName = 'Europe/London';
 
 interface ITweetBody {
   hours_to_match: number;
@@ -8,6 +11,11 @@ interface ITweetBody {
   participants: string;
   date_time: Date;
   tournament: string;
+}
+
+interface UKDateTime {
+  date: string;
+  time: string;
 }
 
 function transformToReadableDate(date: Date): string {
@@ -23,6 +31,15 @@ function transformToReadableTime(date: Date): string {
   return `${currentHour}:${currentMinutes}`;
 }
 
+function convertToUKTimezone(datetime: Date): UKDateTime {
+  const date = momentTz(datetime).tz(UKTimezoneName).format("MMMM DD, YYYY");
+  const time = momentTz(datetime).tz(UKTimezoneName).format("HH:mm");
+  return {
+    date,
+    time
+  }
+}
+
 export function transformToTweetableContent(message: ITweetBody): string {
   let headerTitle: string;
   switch (message.hours_to_match) {
@@ -36,13 +53,15 @@ export function transformToTweetableContent(message: ITweetBody): string {
       headerTitle = "";
   }
 
+  const UKDateTime = convertToUKTimezone(message.date_time);
+
   const transformed = {
     header: headerTitle,
     tournament: `${Emojis.tournament} ${message.tournament}`,
     teams: `${Emojis.versus} ${message.participants}`,
     stadium: `${Emojis.stadium} ${message.stadium}`,
-    date: `${Emojis.date} ${transformToReadableDate(message.date_time)}`,
-    time: `${Emojis.time} ${transformToReadableTime(message.date_time)} GMT+7`,
+    date_time: `${Emojis.date} ${transformToReadableDate(message.date_time)} / ${UKDateTime.date} (UK Date)`,
+    time: `${Emojis.time} ${transformToReadableTime(message.date_time)} GMT+7 / ${UKDateTime.time} (UK Time)`,
     hashtag: `${Team.hashtag}`
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "ioredis": "^5.1.0",
         "moment": "^2.29.4",
         "moment-parseformat": "^4.0.0",
+        "moment-timezone": "^0.5.45",
         "oauth-1.0a": "^2.2.6",
         "pm2": "^5.2.0",
         "ts-node-dev": "^2.0.0"
@@ -8052,6 +8053,17 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/moment-parseformat/-/moment-parseformat-4.0.0.tgz",
       "integrity": "sha512-0V4ICKnI1npglqrMSDK2y8WxOdN79DkMoIexzY3P+jr2wNfbB4J81BgjFfHsj18wBsV7FdKCWyCHcezzH0xlyg=="
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "dependencies": {
+        "moment": "^2.29.4"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -16389,6 +16401,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/moment-parseformat/-/moment-parseformat-4.0.0.tgz",
       "integrity": "sha512-0V4ICKnI1npglqrMSDK2y8WxOdN79DkMoIexzY3P+jr2wNfbB4J81BgjFfHsj18wBsV7FdKCWyCHcezzH0xlyg=="
+    },
+    "moment-timezone": {
+      "version": "0.5.45",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.45.tgz",
+      "integrity": "sha512-HIWmqA86KcmCAhnMAN0wuDOARV/525R2+lOLotuGFzn4HO+FH+/645z2wx0Dt3iDv6/p61SIvKnDstISainhLQ==",
+      "requires": {
+        "moment": "^2.29.4"
+      }
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "ioredis": "^5.1.0",
     "moment": "^2.29.4",
     "moment-parseformat": "^4.0.0",
+    "moment-timezone": "^0.5.45",
     "oauth-1.0a": "^2.2.6",
     "pm2": "^5.2.0",
     "ts-node-dev": "^2.0.0"


### PR DESCRIPTION
Resolves #69 

Preview of the new tweet content:
```bash
{
  text: '\n' +
    '🏆 Premier League\n' +
    '🆚 Brighton vs @ChelseaFC\n' +
    '🏟️ Falmer Stadium\n'  +
    '📅 May 16, 2024 / May 15, 2024 (UK Date)\n' +
    '⏱️ 1:45 GMT+7 / 19:45 (UK Time)\n' +
    '#ChelseaFC #CFCFixture'
}
```

Checklist
- [x] Unit test updated
- [x] Manual test locally

Screenshot of the test