### PR TITLE
Fix/display only in uk time

### DIFF
--- a/enums/months.ts
+++ b/enums/months.ts
@@ -12,18 +12,3 @@ export enum PartialMonthToIndex {
   Nov = 10,
   Dec = 11
 }
-
-export enum MonthIndexToFullMonth {
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December"
-}

--- a/events/subscriber.ts
+++ b/events/subscriber.ts
@@ -51,7 +51,9 @@ class Subscriber {
     const tweetMsg = {
       text: transformedTweetContent
     };
-    await this.httpController.post(tweetMsg);
+
+    console.log(tweetMsg);
+    // await this.httpController.post(tweetMsg);
   }
   
   private shouldSendReminder(reminder_time: number): boolean {
@@ -69,10 +71,10 @@ class Subscriber {
       this.redis.on("message", async (_, message) => {
         const cleansed = JSON.parse(message);
         console.log(`New message received`, cleansed);
-        if (this.shouldSendReminder(cleansed.hours_to_match)) {
+        // if (this.shouldSendReminder(cleansed.hours_to_match)) {
           console.log(`This is attempting to tweet a match that's about to begin in ${cleansed.hours_to_match} hours`)
           await this.sendTweet(cleansed);
-        }
+        // }
       });
     } catch (e) {
       console.log(`an error occured when subscribing message to ${channel} `, e);

--- a/events/subscriber.ts
+++ b/events/subscriber.ts
@@ -51,9 +51,7 @@ class Subscriber {
     const tweetMsg = {
       text: transformedTweetContent
     };
-
-    console.log(tweetMsg);
-    // await this.httpController.post(tweetMsg);
+    await this.httpController.post(tweetMsg);
   }
   
   private shouldSendReminder(reminder_time: number): boolean {
@@ -71,10 +69,10 @@ class Subscriber {
       this.redis.on("message", async (_, message) => {
         const cleansed = JSON.parse(message);
         console.log(`New message received`, cleansed);
-        // if (this.shouldSendReminder(cleansed.hours_to_match)) {
+        if (this.shouldSendReminder(cleansed.hours_to_match)) {
           console.log(`This is attempting to tweet a match that's about to begin in ${cleansed.hours_to_match} hours`)
           await this.sendTweet(cleansed);
-        // }
+        }
       });
     } catch (e) {
       console.log(`an error occured when subscribing message to ${channel} `, e);

--- a/events/subscriber.ts
+++ b/events/subscriber.ts
@@ -2,13 +2,12 @@ import { injectEnv } from "../libs/inject-env";
 import { RedisTerms } from "../constants/redis";
 import { HTTP } from "../modules/http";
 import { transformToTweetableContent } from "../libs/tweet";
-import { addHours } from "../libs/data-conversion";
-import { remindInNHours, Time } from "../constants/time-conversion";
+import { remindInNHours } from "../constants/time-conversion";
 import { RedisStorage } from "../modules/redis";
 
 injectEnv();
 
-const { ENVIRONMENT, REDIS_URL } = process.env;
+const { REDIS_URL } = process.env;
 
 const redisConfig = {
   redisURL: REDIS_URL
@@ -46,10 +45,7 @@ class Subscriber {
       stadium: tweetContent.message.stadium,
       participants: tweetContent.message.participants,
       tournament: tweetContent.message.tournament,
-      date_time:
-        ENVIRONMENT === "production"
-          ? addHours(Time.UTCToLocalTimezone, matchSchedule)
-          : matchSchedule
+      date_time: matchSchedule
     };
     const transformedTweetContent = transformToTweetableContent(contentToTransform);
     const tweetMsg = {

--- a/jobs/match-reader.ts
+++ b/jobs/match-reader.ts
@@ -43,7 +43,7 @@ class MatchReader {
   
     console.log(`Upcoming match ${JSON.stringify(matches[0])} will be played in ${diffInHours} hour(s)`);
   
-    if (diffInHours <= Time.hoursInADay) {
+    // if (diffInHours <= Time.hoursInADay) {
       const msg: IBody = {
         message: matches[0],
         hours_to_match: diffInHours
@@ -58,7 +58,7 @@ class MatchReader {
   
         await this.redis.set(RedisTerms.keyName, JSON.stringify(matches), currentTTL);
       }
-    }
+    // }
   }
 }
 

--- a/jobs/match-reader.ts
+++ b/jobs/match-reader.ts
@@ -43,7 +43,7 @@ class MatchReader {
   
     console.log(`Upcoming match ${JSON.stringify(matches[0])} will be played in ${diffInHours} hour(s)`);
   
-    // if (diffInHours <= Time.hoursInADay) {
+    if (diffInHours <= Time.hoursInADay) {
       const msg: IBody = {
         message: matches[0],
         hours_to_match: diffInHours
@@ -58,7 +58,7 @@ class MatchReader {
   
         await this.redis.set(RedisTerms.keyName, JSON.stringify(matches), currentTTL);
       }
-    // }
+    }
   }
 }
 

--- a/libs/tweet.test.ts
+++ b/libs/tweet.test.ts
@@ -1,4 +1,4 @@
-import { transformToTweetableContent, exportedForTesting } from "./tweet";
+import { transformToTweetableContent } from "./tweet";
 import { Emojis } from "../enums/emojis";
 
 const fixedDate = new Date(2022, 10, 10, 10, 10, 10);
@@ -10,26 +10,6 @@ const templateBody = {
 };
 
 describe("tweet-related libs testing", () => {
-  test("test the transformToReadableTime - normal flow", () => {
-    const data = exportedForTesting.transformToReadableTime(fixedDate);
-    expect(typeof data).toBe("string");
-    expect(data).toBe("10:10");
-  });
-
-  test("test the transformToReadableTime - minutes less than 10 gets added 0 in the beginning", () => {
-    const dateWithCustomTime = new Date(2022, 10, 10, 10, 5, 20);
-    const data = exportedForTesting.transformToReadableTime(dateWithCustomTime);
-    expect(typeof data).toBe("string");
-    expect(data).toBe("10:05");
-  });
-
-  test("test the transformToReadableDate - normal flow", () => {
-    const data = exportedForTesting.transformToReadableDate(fixedDate);
-    expect(typeof data).toBe("string");
-    expect(data).toContain(",");
-    expect(data).toBe("November 10, 2022");
-  });
-
   test("transformToTweetableContent - 1 hour before the match", async () => {
     const body = {
       hours_to_match: 1,

--- a/libs/tweet.ts
+++ b/libs/tweet.ts
@@ -1,9 +1,8 @@
+import * as moment from "moment-timezone";
 import { Emojis } from "../enums/emojis";
-import { MonthIndexToFullMonth } from "../enums/months";
 import { Team } from "../constants/team";
-import momentTz = require('moment-timezone');
 
-const UKTimezoneName = 'Europe/London';
+const UKTimeZoneName = "Europe/London";
 
 interface ITweetBody {
   hours_to_match: number;
@@ -11,33 +10,6 @@ interface ITweetBody {
   participants: string;
   date_time: Date;
   tournament: string;
-}
-
-interface UKDateTime {
-  date: string;
-  time: string;
-}
-
-function transformToReadableDate(date: Date): string {
-  const currentDate = date.getDate();
-  const currentMonth = MonthIndexToFullMonth[date.getMonth()];
-  const currentYear = date.getFullYear();
-  return `${currentMonth} ${currentDate}, ${currentYear}`;
-}
-
-function transformToReadableTime(date: Date): string {
-  const currentHour = date.getHours();
-  const currentMinutes = date.getMinutes() < 10 ? `0${date.getMinutes()}` : date.getMinutes();
-  return `${currentHour}:${currentMinutes}`;
-}
-
-function convertToUKTimezone(datetime: Date): UKDateTime {
-  const date = momentTz(datetime).tz(UKTimezoneName).format("MMMM DD, YYYY");
-  const time = momentTz(datetime).tz(UKTimezoneName).format("HH:mm");
-  return {
-    date,
-    time
-  }
 }
 
 export function transformToTweetableContent(message: ITweetBody): string {
@@ -53,22 +25,18 @@ export function transformToTweetableContent(message: ITweetBody): string {
       headerTitle = "";
   }
 
-  const UKDateTime = convertToUKTimezone(message.date_time);
+  const UKDate = moment(message.date_time).tz(UKTimeZoneName).format("dddd, MMMM DD, YYYY");
+  const UKTime = moment(message.date_time).tz(UKTimeZoneName).format("HH:mm");
 
   const transformed = {
     header: headerTitle,
     tournament: `${Emojis.tournament} ${message.tournament}`,
     teams: `${Emojis.versus} ${message.participants}`,
     stadium: `${Emojis.stadium} ${message.stadium}`,
-    date_time: `${Emojis.date} ${transformToReadableDate(message.date_time)} / ${UKDateTime.date} (UK Date)`,
-    time: `${Emojis.time} ${transformToReadableTime(message.date_time)} GMT+7 / ${UKDateTime.time} (UK Time)`,
+    date_time: `${Emojis.date} ${UKDate} (UK Date)`,
+    time: `${Emojis.time} ${UKTime} (UK Time)`,
     hashtag: `${Team.hashtag}`
   };
 
   return Object.values(transformed).join("\n").toString() as string;
 }
-
-export const exportedForTesting = {
-  transformToReadableDate,
-  transformToReadableTime
-};


### PR DESCRIPTION
Resolves #72 

Checklist
- [x] Unit test updated
- [x] Manual test locally

Screenshot of the test:
```bash
2024-05-15T09:10:32.872656+00:00 app[worker.1]: This is attempting to tweet a match that's about to begin in 10 hours
2024-05-15T09:10:32.877758+00:00 app[worker.1]: {
2024-05-15T09:10:32.877759+00:00 app[worker.1]: text: '\n' +
2024-05-15T09:10:32.877759+00:00 app[worker.1]: '🏆 Premier League\n' +
2024-05-15T09:10:32.877760+00:00 app[worker.1]: '🆚 Brighton vs @ChelseaFC\n' +
2024-05-15T09:10:32.877760+00:00 app[worker.1]: '🏟️ Falmer Stadium\n' +
2024-05-15T09:10:32.877763+00:00 app[worker.1]: '📅 Wednesday, May 15, 2024 (UK Date)\n' +
2024-05-15T09:10:32.877763+00:00 app[worker.1]: '⏱️ 19:45 (UK Time)\n' +
2024-05-15T09:10:32.877763+00:00 app[worker.1]: '#ChelseaFC #CFCFixture'
2024-05-15T09:10:32.877763+00:00 app[worker.1]: }
```