### PR TITLE
feat(hashtag): add tournament name to the hashtag

### DIFF
--- a/libs/tweet.test.ts
+++ b/libs/tweet.test.ts
@@ -23,6 +23,9 @@ describe("tweet-related libs testing", () => {
     expect(data).toContain(Emojis.versus);
     expect(data).toContain('#');
     expect(data).toContain('[Matchday! ONE HOUR TO GO]');
+
+    const hashTagCount = (data.match(/#/g) || []).length;
+    expect(hashTagCount).toEqual(3);
   });
 
   test("transformToTweetableContent - 24 hours before the match", async () => {
@@ -34,6 +37,9 @@ describe("tweet-related libs testing", () => {
     expect(typeof data).toBe("string");
     expect(data).toContain('#');
     expect(data).toContain('[Day - 1!]')
+
+    const hashTagCount = (data.match(/#/g) || []).length;
+    expect(hashTagCount).toEqual(3);
   });
 
   test("transformToTweetableContent - other hours before the match", async () => {
@@ -44,5 +50,8 @@ describe("tweet-related libs testing", () => {
     const data = transformToTweetableContent(body);
     expect(typeof data).toBe("string");
     expect(data).toContain('#');
+
+    const hashTagCount = (data.match(/#/g) || []).length;
+    expect(hashTagCount).toEqual(3);
   });
 });

--- a/libs/tweet.test.ts
+++ b/libs/tweet.test.ts
@@ -21,6 +21,8 @@ describe("tweet-related libs testing", () => {
     expect(data).toContain(Emojis.stadium);
     expect(data).toContain(Emojis.time);
     expect(data).toContain(Emojis.versus);
+    expect(data).toContain('#');
+    expect(data).toContain('[Matchday! ONE HOUR TO GO]');
   });
 
   test("transformToTweetableContent - 24 hours before the match", async () => {
@@ -30,6 +32,8 @@ describe("tweet-related libs testing", () => {
     };
     const data = transformToTweetableContent(body);
     expect(typeof data).toBe("string");
+    expect(data).toContain('#');
+    expect(data).toContain('[Day - 1!]')
   });
 
   test("transformToTweetableContent - other hours before the match", async () => {
@@ -39,5 +43,6 @@ describe("tweet-related libs testing", () => {
     };
     const data = transformToTweetableContent(body);
     expect(typeof data).toBe("string");
+    expect(data).toContain('#');
   });
 });

--- a/libs/tweet.ts
+++ b/libs/tweet.ts
@@ -12,6 +12,10 @@ interface ITweetBody {
   tournament: string;
 }
 
+function convertTournamentToHashTag(tournament: string): string {
+  return `#${tournament.replace(/ /g, '')}`;
+}
+
 export function transformToTweetableContent(message: ITweetBody): string {
   let headerTitle: string;
   switch (message.hours_to_match) {
@@ -35,7 +39,7 @@ export function transformToTweetableContent(message: ITweetBody): string {
     stadium: `${Emojis.stadium} ${message.stadium}`,
     date_time: `${Emojis.date} ${UKDate} (UK Date)`,
     time: `${Emojis.time} ${UKTime} (UK Time)`,
-    hashtag: `${Team.hashtag}`
+    hashtag: `${Team.hashtag} ${convertTournamentToHashTag(message.tournament)}`
   };
 
   return Object.values(transformed).join("\n").toString() as string;


### PR DESCRIPTION
Resolves #23 

Checklist
- [x] Unit test updated
- [x] Manual test locally

Screenshot of the test:
```bash
 console.log

    🏆 Champions League
    🆚 Chelsea vs Atletico
    🏟️ Stamford Bridge
    📅 Thursday, November 10, 2022 (UK Date)
    ⏱️ 03:10 (UK Time)
    #ChelseaFC #CFCFixture #ChampionsLeague 
```